### PR TITLE
fix: use IMDSv2 by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ Optional policies have the option of being created by default, but are specified
 | unique\_suffix | Enables/disables generation of a unique suffix to cluster name | `bool` | `true` | yes |
 | vpc\_id | VPC ID to create resources in | `string` | n/a | yes |
 | wait_for_capacity_timeout | How long Terraform should wait for ASG instances to be healthy before timing out. | `string` | `"10m"` | no |
+| metadata_options | Instance Metadata Options | `map` | <pre>{<br>  http_endpoint: "enabled",<br>  http_tokens: "required",<br>  http_put_response_hop_limit: 1,<br>  instance_metadata_tags: "disabled"}</pre> | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -189,6 +189,7 @@ module "servers" {
   spot                        = var.spot
   load_balancers              = [module.cp_lb.name]
   wait_for_capacity_timeout   = var.wait_for_capacity_timeout
+  metadata_options            = var.metadata_options
 
   # Overrideable variables
   userdata             = data.template_cloudinit_config.this.rendered

--- a/modules/agent-nodepool/README.md
+++ b/modules/agent-nodepool/README.md
@@ -29,6 +29,7 @@
 | vpc\_id | VPC ID to create resources in | `string` | n/a | yes |
 | wait_for_capacity_timeout | How long Terraform should wait for ASG instances to be healthy before timing out. | `string` | `"10m"` | no |
 | metadata_options | Instance Metadata Options | `map` | <pre>{<br>  http_endpoint: "enabled",<br>  http_tokens: "required",<br>  http_put_response_hop_limit: 2,<br>  instance_metadata_tags: "disabled"}</pre> | no |
+## Outputs
 
 | Name | Description |
 |------|-------------|

--- a/modules/agent-nodepool/README.md
+++ b/modules/agent-nodepool/README.md
@@ -28,7 +28,7 @@
 | tags | Map of additional tags to add to all resources created | `map(string)` | `{}` | no |
 | vpc\_id | VPC ID to create resources in | `string` | n/a | yes |
 | wait_for_capacity_timeout | How long Terraform should wait for ASG instances to be healthy before timing out. | `string` | `"10m"` | no |
-## Outputs
+| metadata_options | Instance Metadata Options | `map` | <pre>{<br>  http_endpoint: "enabled",<br>  http_tokens: "required",<br>  http_put_response_hop_limit: 2,<br>  instance_metadata_tags: "disabled"}</pre> | no |
 
 | Name | Description |
 |------|-------------|

--- a/modules/agent-nodepool/main.tf
+++ b/modules/agent-nodepool/main.tf
@@ -121,6 +121,7 @@ module "nodepool" {
   asg                         = var.asg
   spot                        = var.spot
   wait_for_capacity_timeout   = var.wait_for_capacity_timeout
+  metadata_options            = var.metadata_options
 
   tags = merge({
     "Role" = "agent",

--- a/modules/agent-nodepool/variables.tf
+++ b/modules/agent-nodepool/variables.tf
@@ -95,6 +95,17 @@ variable "extra_security_group_ids" {
   default     = []
 }
 
+variable "metadata_options" {
+  type        = map
+  default     = {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required" # IMDS-v2
+    http_put_response_hop_limit = 2          # allow pods to use IMDS as well
+    instance_metadata_tags      = "disabled"
+  }
+  description = "Instance Metadata Options"
+}
+
 #
 # RKE2 Variables
 #

--- a/modules/nodepool/main.tf
+++ b/modules/nodepool/main.tf
@@ -17,6 +17,13 @@ resource "aws_launch_template" "this" {
   user_data              = var.userdata
   vpc_security_group_ids = concat([aws_security_group.this.id], var.vpc_security_group_ids)
 
+  metadata_options {
+    http_endpoint               = var.metadata_options["http_endpoint"]
+    http_tokens                 = var.metadata_options["http_tokens"]
+    http_put_response_hop_limit = var.metadata_options["http_put_response_hop_limit"]
+    instance_metadata_tags      = var.metadata_options["instance_metadata_tags"]
+  }
+
   block_device_mappings {
     device_name = lookup(var.block_device_mappings, "device_name", "/dev/sda1")
     ebs {

--- a/modules/nodepool/variables.tf
+++ b/modules/nodepool/variables.tf
@@ -92,3 +92,8 @@ variable "min_elb_capacity" {
   type    = number
   default = null
 }
+
+variable "metadata_options" {
+  type        = map
+  description = "Instance Metadata Options"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -118,6 +118,17 @@ variable "controlplane_access_logs_bucket" {
   default     = "disabled"
 }
 
+variable "metadata_options" {
+  type        = map
+  default     = {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required" # IMDS-v2
+    http_put_response_hop_limit = 2          # allow pods to use IMDS as well
+    instance_metadata_tags      = "disabled"
+  }
+  description = "Instance Metadata Options"
+}
+
 #
 # RKE2 Variables
 #


### PR DESCRIPTION
## Problem:
This module is currently using IDMSv1. We should use IDMSv2 to address a high severity finding (link below)

https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#fsbp-ec2-8

## Solution:
1. Add variables to allow users to set IMDS config
2. By default use IMDSv2
3. Update init script to use IMDSv2